### PR TITLE
TKW-16 - Refactor publish workflows to disable E2E testing jobs

### DIFF
--- a/.eas/workflows/publish-staging-ota.yml
+++ b/.eas/workflows/publish-staging-ota.yml
@@ -4,82 +4,82 @@ on:
     labels: ["eas-staging-ota"]
     
 jobs:
-  build_android_for_e2e:
-    type: build
-    params:
-      platform: android
-      profile: e2e-test # your eas build profile for E2E test
+  # build_android_for_e2e:
+  #   type: build
+  #   params:
+  #     platform: android
+  #     profile: e2e-test # your eas build profile for E2E test
 
-  build_ios_for_e2e:
-    type: build
-    params:
-      platform: ios
-      profile: e2e-test # your eas build profile for E2E test
+  # build_ios_for_e2e:
+  #   type: build
+  #   params:
+  #     platform: ios
+  #     profile: e2e-test # your eas build profile for E2E test
 
-  maestro_test_android:
-    needs: [build_android_for_e2e]
-    type: maestro
-    environment: preview
-    params:
-      build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
-      flow_path: ./maestro/flows
+  # maestro_test_android:
+  #   needs: [build_android_for_e2e]
+  #   type: maestro
+  #   environment: preview
+  #   params:
+  #     build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
+  #     flow_path: ./maestro/flows
 
-  maestro_test_ios:
-    needs: [build_ios_for_e2e]
-    type: maestro
-    environment: preview
-    params:
-      build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}
-      flow_path: ./maestro/flows
+  # maestro_test_ios:
+  #   needs: [build_ios_for_e2e]
+  #   type: maestro
+  #   environment: preview
+  #   params:
+  #     build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}
+  #     flow_path: ./maestro/flows
 
   # Notifty maestro test results (success or failure)
-  notify_maestro_results:
-    after: [maestro_test_android, maestro_test_ios]
-    steps:
-      - run: |
-          set -e
-          MSG=""
-          # Android test results
-          if [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "success" ]]; then
-            MSG+="✅ Android E2E tests passed.\n"
-          elif [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "failure" ]]; then
-            MSG+="🚨 Android E2E tests failed.\n"
-          fi
-          # iOS test results
-          if [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "success" ]]; then
-            MSG+="✅ iOS E2E tests passed.\n"
-          elif [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "failure" ]]; then
-            MSG+="🚨 iOS E2E tests failed.\n"
-          fi
-          # Send consolidated Slack notification
-          curl -X POST -H 'Content-type: application/json' \
-            --data "{ \
-              \"username\": \"EAS - WORKFLOWS\", \
-              \"icon_url\": \"https://raw.githubusercontent.com/nyplex/bot-icons/main/expo-icon.png\", \
-              \"channel\": \"task-wan\", \
-              \"attachments\": [ \
-                { \
-                  \"fallback\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
-                  \"pretext\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
-                  \"color\": \"#36A2EB\", \
-                  \"fields\": [ \
-                    { \
-                      \"title\": \"Details\", \
-                      \"value\": \"$MSG\", \
-                      \"short\": false \
-                    } \
-                  ] \
-                } \
-              ] \
-            }" \
-            "$SLACK_WEBHOOK_URL"
-    env:
-      AFTER_MAESTRO_TEST_ANDROID_STATUS: ${{ after.maestro_test_android.status }}
-      AFTER_MAESTRO_TEST_IOS_STATUS: ${{ after.maestro_test_ios.status
+  # notify_maestro_results:
+  #   after: [maestro_test_android, maestro_test_ios]
+  #   steps:
+  #     - run: |
+  #         set -e
+  #         MSG=""
+  #         # Android test results
+  #         if [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "success" ]]; then
+  #           MSG+="✅ Android E2E tests passed.\n"
+  #         elif [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "failure" ]]; then
+  #           MSG+="🚨 Android E2E tests failed.\n"
+  #         fi
+  #         # iOS test results
+  #         if [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "success" ]]; then
+  #           MSG+="✅ iOS E2E tests passed.\n"
+  #         elif [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "failure" ]]; then
+  #           MSG+="🚨 iOS E2E tests failed.\n"
+  #         fi
+  #         # Send consolidated Slack notification
+  #         curl -X POST -H 'Content-type: application/json' \
+  #           --data "{ \
+  #             \"username\": \"EAS - WORKFLOWS\", \
+  #             \"icon_url\": \"https://raw.githubusercontent.com/nyplex/bot-icons/main/expo-icon.png\", \
+  #             \"channel\": \"task-wan\", \
+  #             \"attachments\": [ \
+  #               { \
+  #                 \"fallback\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
+  #                 \"pretext\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
+  #                 \"color\": \"#36A2EB\", \
+  #                 \"fields\": [ \
+  #                   { \
+  #                     \"title\": \"Details\", \
+  #                     \"value\": \"$MSG\", \
+  #                     \"short\": false \
+  #                   } \
+  #                 ] \
+  #               } \
+  #             ] \
+  #           }" \
+  #           "$SLACK_WEBHOOK_URL"
+  #   env:
+  #     AFTER_MAESTRO_TEST_ANDROID_STATUS: ${{ after.maestro_test_android.status }}
+  #     AFTER_MAESTRO_TEST_IOS_STATUS: ${{ after.maestro_test_ios.status
 
   fingerprint:
-    after: [maestro_test_android, maestro_test_ios]
-    if: success()
+    # after: [maestro_test_android, maestro_test_ios]
+    # if: success()
     type: fingerprint
     environment: preview
     env: 

--- a/.eas/workflows/publish-staging.yml
+++ b/.eas/workflows/publish-staging.yml
@@ -4,90 +4,90 @@ on:
     labels: ["eas-staging"]
 
 jobs:
-  build_android_for_e2e:
-    type: build
-    params:
-      platform: android
-      profile: e2e-test # your eas build profile for E2E test
+  # build_android_for_e2e:
+  #   type: build
+  #   params:
+  #     platform: android
+  #     profile: e2e-test # your eas build profile for E2E test
 
-  build_ios_for_e2e:
-    type: build
-    params:
-      platform: ios
-      profile: e2e-test # your eas build profile for E2E test
+  # build_ios_for_e2e:
+  #   type: build
+  #   params:
+  #     platform: ios
+  #     profile: e2e-test # your eas build profile for E2E test
 
-  maestro_test_android:
-    needs: [build_android_for_e2e]
-    type: maestro
-    environment: preview
-    params:
-      build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
-      flow_path: ./maestro/flows
+  # maestro_test_android:
+  #   needs: [build_android_for_e2e]
+  #   type: maestro
+  #   environment: preview
+  #   params:
+  #     build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
+  #     flow_path: ./maestro/flows
 
-  maestro_test_ios:
-    needs: [build_ios_for_e2e]
-    type: maestro
-    environment: preview
-    params:
-      build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}
-      flow_path: ./maestro/flows
+  # maestro_test_ios:
+  #   needs: [build_ios_for_e2e]
+  #   type: maestro
+  #   environment: preview
+  #   params:
+  #     build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}
+  #     flow_path: ./maestro/flows
 
   # Notifty maestro test results (success or failure)
-  notify_maestro_results:
-    after: [maestro_test_android, maestro_test_ios]
-    steps:
-      - run: |
-          set -e
-          MSG=""
-          # Android test results
-          if [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "success" ]]; then
-            MSG+="✅ Android E2E tests passed.\n"
-          elif [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "failure" ]]; then
-            MSG+="🚨 Android E2E tests failed.\n"
-          fi
-          # iOS test results
-          if [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "success" ]]; then
-            MSG+="✅ iOS E2E tests passed.\n"
-          elif [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "failure" ]]; then
-            MSG+="🚨 iOS E2E tests failed.\n"
-          fi
-          # Send consolidated Slack notification
-          curl -X POST -H 'Content-type: application/json' \
-            --data "{ \
-              \"username\": \"EAS - WORKFLOWS\", \
-              \"icon_url\": \"https://raw.githubusercontent.com/nyplex/bot-icons/main/expo-icon.png\", \
-              \"channel\": \"task-wan\", \
-              \"attachments\": [ \
-                { \
-                  \"fallback\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
-                  \"pretext\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
-                  \"color\": \"#36A2EB\", \
-                  \"fields\": [ \
-                    { \
-                      \"title\": \"Details\", \
-                      \"value\": \"$MSG\", \
-                      \"short\": false \
-                    } \
-                  ] \
-                } \
-              ] \
-            }" \
-            "$SLACK_WEBHOOK_URL"
-    env:
-      AFTER_MAESTRO_TEST_ANDROID_STATUS: ${{ after.maestro_test_android.status }}
-      AFTER_MAESTRO_TEST_IOS_STATUS: ${{ after.maestro_test_ios.status
+  # notify_maestro_results:
+  #   after: [maestro_test_android, maestro_test_ios]
+  #   steps:
+  #     - run: |
+  #         set -e
+  #         MSG=""
+  #         # Android test results
+  #         if [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "success" ]]; then
+  #           MSG+="✅ Android E2E tests passed.\n"
+  #         elif [[ "${AFTER_MAESTRO_TEST_ANDROID_STATUS}" == "failure" ]]; then
+  #           MSG+="🚨 Android E2E tests failed.\n"
+  #         fi
+  #         # iOS test results
+  #         if [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "success" ]]; then
+  #           MSG+="✅ iOS E2E tests passed.\n"
+  #         elif [[ "${AFTER_MAESTRO_TEST_IOS_STATUS}" == "failure" ]]; then
+  #           MSG+="🚨 iOS E2E tests failed.\n"
+  #         fi
+  #         # Send consolidated Slack notification
+  #         curl -X POST -H 'Content-type: application/json' \
+  #           --data "{ \
+  #             \"username\": \"EAS - WORKFLOWS\", \
+  #             \"icon_url\": \"https://raw.githubusercontent.com/nyplex/bot-icons/main/expo-icon.png\", \
+  #             \"channel\": \"task-wan\", \
+  #             \"attachments\": [ \
+  #               { \
+  #                 \"fallback\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
+  #                 \"pretext\": \"📣 Maestro E2E Tests Results: <https://expo.dev/accounts/nyplex-studio/projects/task-wan/workflows|Check workflows>\", \
+  #                 \"color\": \"#36A2EB\", \
+  #                 \"fields\": [ \
+  #                   { \
+  #                     \"title\": \"Details\", \
+  #                     \"value\": \"$MSG\", \
+  #                     \"short\": false \
+  #                   } \
+  #                 ] \
+  #               } \
+  #             ] \
+  #           }" \
+  #           "$SLACK_WEBHOOK_URL"
+  #   env:
+  #     AFTER_MAESTRO_TEST_ANDROID_STATUS: ${{ after.maestro_test_android.status }}
+  #     AFTER_MAESTRO_TEST_IOS_STATUS: ${{ after.maestro_test_ios.status
 
   build_android:
-    after: [maestro_test_android, maestro_test_ios]
-    if: success()
+    # after: [maestro_test_android, maestro_test_ios]
+    # if: success()
     type: build
     params:
       platform: android
       profile: staging
 
   build_ios:
-    after: [maestro_test_android, maestro_test_ios]
-    if: success()
+    # after: [maestro_test_android, maestro_test_ios]
+    # if: success()
     type: build
     params:
       platform: ios

--- a/app.config.ts
+++ b/app.config.ts
@@ -6,6 +6,9 @@ const withFirebaseNotificationMetaFix = require("./plugins/withFirebaseNotificat
 const IS_DEV = process.env.EXPO_PUBLIC_APP_VARIANT === "development";
 const IS_PREVIEW = process.env.EXPO_PUBLIC_APP_VARIANT === "preview";
 const IS_STAGING = process.env.EXPO_PUBLIC_APP_VARIANT === "staging";
+const GOOGLE_SERVICES = IS_STAGING
+  ? process.env.GOOGLE_SERVICES_STAGING
+  : process.env.GOOGLE_SERVICES;
 
 const getUniqueIdentifier = () => {
   if (IS_DEV) {
@@ -50,7 +53,7 @@ export default ({ config }: { config: any }) => ({
   android: {
     ...config.android,
     package: getUniqueIdentifier(),
-    googleServicesFile: process.env.GOOGLE_SERVICES,
+    googleServicesFile: GOOGLE_SERVICES,
   },
   plugins: [
     ...config.plugins,


### PR DESCRIPTION
Commented out E2E testing jobs and notifications in the publish workflows for a cleaner configuration. Updated the handling of Google services based on the app variant.