### PR TITLE
TKW-16 - Add environment variable for staging builds in publish workflow

### DIFF
--- a/.eas/workflows/publish-staging.yml
+++ b/.eas/workflows/publish-staging.yml
@@ -81,6 +81,8 @@ jobs:
     # after: [maestro_test_android, maestro_test_ios]
     # if: success()
     type: build
+    env: 
+      EXPO_PUBLIC_APP_VARIANT: "staging"
     params:
       platform: android
       profile: staging
@@ -89,6 +91,8 @@ jobs:
     # after: [maestro_test_android, maestro_test_ios]
     # if: success()
     type: build
+    env: 
+      EXPO_PUBLIC_APP_VARIANT: "staging"
     params:
       platform: ios
       profile: staging


### PR DESCRIPTION
Introduce an environment variable to specify the app variant as "staging" in the publish workflow for both Android and iOS builds.