### PR TITLE
TKW-36 - Fix condition checks in publish-preview workflow

### DIFF
--- a/.eas/workflows/publish-preview.yml
+++ b/.eas/workflows/publish-preview.yml
@@ -195,11 +195,11 @@ jobs:
     #   AFTER_UPDATE_IOS_STATUS: ${{ after.update_ios.status }}
     if: |
       (
-        after.build_android_if_missing == 'success' ||
+        after.build_android_if_missing.status == 'success' ||
         after.update_android.status == 'success'
       ) &&
       (
-        after.build_ios_if_missing == 'success' ||
+        after.build_ios_if_missing.status == 'success' ||
         after.update_ios.status == 'success'
       )
     steps:


### PR DESCRIPTION
Update condition checks to correctly access the status property for build results in the publish-preview workflow.