### PR TITLE
TKW-67 - Update workflow name and fix iOS build condition

### DIFF
--- a/.eas/workflows/build-development.yml
+++ b/.eas/workflows/build-development.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Development
 
 jobs:
   # 1. Fingerprint job to check for existing builds
@@ -42,7 +42,7 @@ jobs:
   build_ios_app:
     type: build
     needs: [get_ios_build]
-    if: ${{ needs.get_ios_build.outputs.build_id }}
+    if: ${{ !needs.get_ios_build.outputs.build_id }}
     params:
       platform: ios
       profile: development

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ on:
       - develop
       - main
       - staging
-      - "story/**"
+      - "feature/**"
 
 jobs:
   test-and-lint:


### PR DESCRIPTION
Change the workflow name to 'Build Development' and correct the condition for the iOS app build to ensure it runs only when there is no existing build.